### PR TITLE
net/packet: rx_owner_map depends on pg_vec

### DIFF
--- a/net/packet/af_packet.c
+++ b/net/packet/af_packet.c
@@ -4461,9 +4461,10 @@ static int packet_set_ring(struct sock *sk, union tpacket_req_u *req_u,
 	}
 
 out_free_pg_vec:
-	bitmap_free(rx_owner_map);
-	if (pg_vec)
+	if (pg_vec) {
+		bitmap_free(rx_owner_map);
 		free_pg_vec(pg_vec, order, req->tp_block_nr);
+	}
 out:
 	return err;
 }


### PR DESCRIPTION
Fix for CVE-2021-22600.